### PR TITLE
change to include package data (e.g. analysis/db)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ setup(
 
     install_requires=["numpy"],
 
+    include_package_data=True,
+
     keywords='',
 
     packages=find_packages(),


### PR DESCRIPTION
Importing the package gave errors because the data in analysis/db was not included in the installation, done via pip. I updated setup.py such that such folders are included when installing the package.