### PR TITLE
updates to make cellbrowser.py faster and easier to use

### DIFF
--- a/neals_python_functions/analysis/cellbrowser.py
+++ b/neals_python_functions/analysis/cellbrowser.py
@@ -5,7 +5,7 @@ import os
 
 def _make_expr_mtx(adata, output_filepath):
     # Make the expression matrix
-    expr_mtx = pd.DataFrame(adata.X.todense(), index=adata.obs_names).T
+    expr_mtx = pd.DataFrame.sparse.from_spmatrix(adata.X.T, columns=adata.obs_names)
     expr_mtx["gene"] = adata.var_names
 
     # Adjust the columns so genes is first


### PR DESCRIPTION
March 6:
- split `_make_cell_browser_files` into multiple functions so files can be updated individually if needed
- create `exprMatrix.tsv.gz` instead of `expr_mtx.csv.gz` so UCSC `cellbrowser` module copies the file instead of rewriting it (this makes it slightly faster)
- some general updates for the latest version of UCSC `cellbrowser` package

March 10:
- used `pd.DataFrame.sparse.from_spmatrix` when creating dataframe for making `exprMatrix.tsv.gz`, which uses much less memory